### PR TITLE
fix: Import git-hooks.nix in flakeModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,8 @@ in `.github/workflows/main.yaml`.
 
 ## Installation
 
-This project uses [flake-parts](https://github.com/hercules-ci/flake-parts) and
-[git-hooks.nix](https://github.com/cachix/git-hooks.nix). You need to add both
-as inputs to your `flake.nix` and import the modules exposed by this repository
-and `git-hooks.nix` to then be able to configure your own workflows. Example of
-the module importing is shown below:
+This project uses `flake-parts`. You need to add the module exposed by this
+repository and configure your own workflows.
 
 ```nix
   inputs.flake-parts.lib.mkFlake { inherit inputs; }
@@ -45,7 +42,6 @@ the module importing is shown below:
       {
         imports = [
           inputs.actions-nix.flakeModules.default
-          inputs.git-hooks.flakeModule
           # Module config for your repository (replace with your own below)
           # ./ci
         ];

--- a/flake.lock
+++ b/flake.lock
@@ -36,10 +36,32 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -73,33 +95,11 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1737465171,
-        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
-    pre-commit-hooks = {
-      url = "github:cachix/pre-commit-hooks.nix";
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,8 +6,9 @@ let
       let
         inherit (flake-parts-lib) importApply;
         flakeModules = let
-          actions-nix =
-            importApply ./flake-modules/actions-nix { inherit withSystem; };
+          actions-nix = importApply ./flake-modules/actions-nix {
+            inherit withSystem inputs;
+          };
         in {
           inherit actions-nix;
           default = actions-nix;
@@ -15,9 +16,9 @@ let
         lib = import ./lib { inherit (inputs.nixpkgs) lib; };
 
       in {
-        systems = [ "x86_64-linux" ];
+        systems = [ "x86_64-linux" "aarch64-darwin" ];
         imports = [
-          inputs.pre-commit-hooks.flakeModule
+          inputs.git-hooks.flakeModule
           # Module definition
           flakeModules.actions-nix
           # Module config for this repository

--- a/nix/flake-modules/actions-nix/default.nix
+++ b/nix/flake-modules/actions-nix/default.nix
@@ -6,6 +6,7 @@ _localFlake:
 # Regular module arguments; self, inputs, etc all reference the final user flake,
 # where this module was imported.
 { config, lib, flake-parts-lib, ... }: {
+  imports = [ _localFlake.inputs.git-hooks.flakeModule ];
   options = let inherit (lib) types;
   in {
 


### PR DESCRIPTION
Import git-hooks.nix in flakeModule, removing need to add git-hooks.nix at use sites. 
Additionally switch to git-hooks.nix from pre-commit-hooks.nix

Fixes #14