### PR TITLE
fix: Render multi-line strings with "|"

### DIFF
--- a/nix/flake-modules/actions-nix/render.py
+++ b/nix/flake-modules/actions-nix/render.py
@@ -28,6 +28,14 @@ def evaluate(
     workflows: dict[str, dict[str, str]] = json.loads(workflows_json)
     return workflows
 
+def yaml_multiline_string_pipe(dumper, data):
+    text_list = [line.rstrip() for line in data.splitlines()]
+    fixed_data = "\n".join(text_list)
+    if len(text_list) > 1:
+        return dumper.represent_scalar('tag:yaml.org,2002:str', fixed_data, style="|")
+    return dumper.represent_scalar('tag:yaml.org,2002:str', fixed_data)
+
+yaml.add_representer(str, yaml_multiline_string_pipe)
 
 def main(evaluated_ci_path: Optional[Path]):
     if evaluated_ci_path is None:


### PR DESCRIPTION
```
test: 'asdf

  fdsa

  '
```

to 

```
"test": |-
  asdf
  fdsa
```