### PR TITLE
fix(pre-commit): use fresh nix eval to pick up staged changes

### DIFF
--- a/nix/flake-modules/actions-nix/default.nix
+++ b/nix/flake-modules/actions-nix/default.nix
@@ -31,7 +31,7 @@ _localFlake:
     };
   config = {
     perSystem =
-      { pkgs, self', ... }:
+      { pkgs, ... }:
       {
         # TODO: Should definition not be automatic on flake-module import?
         pre-commit.settings.hooks = {
@@ -41,11 +41,14 @@ _localFlake:
             pass_filenames = false;
             always_run = true;
             description = "Render nix-configured workflow to respective yaml file";
+            # Don't use packages.render-workflows here - its evaluated JSON is
+            # frozen at devshell entry time. Instead, run render.py without
+            # --evaluated-ci-path so it does a fresh `nix eval` at commit time.
             entry =
               let
-                renderCI = self'.packages.render-workflows;
+                pythonEnv = pkgs.python3.withPackages (p: [ p.pyyaml ]);
               in
-              "${renderCI}/bin/render-workflows";
+              "${pythonEnv}/bin/python3 ${./render.py}";
           };
         };
 

--- a/nix/flake-modules/actions-nix/render.py
+++ b/nix/flake-modules/actions-nix/render.py
@@ -68,4 +68,8 @@ if __name__ == "__main__":
     argparser = argparse.ArgumentParser()
     argparser.add_argument("--evaluated-ci-path", required=False)
     args = argparser.parse_args()
-    main(evaluated_ci_path=Path(args.evaluated_ci_path))
+    main(
+        evaluated_ci_path=Path(args.evaluated_ci_path)
+        if args.evaluated_ci_path
+        else None
+    )

--- a/nix/flake-modules/actions-nix/render.py
+++ b/nix/flake-modules/actions-nix/render.py
@@ -47,7 +47,7 @@ def main(evaluated_ci_path: Optional[Path]):
                 "--option",
                 "experimental-features",
                 "nix-command flakes",
-                ".#ci.workflows",
+                ".#actions-nix.workflows",
                 "--json",
             ],
             text=True,


### PR DESCRIPTION
## Summary

The pre-commit hook was rendering workflows based on the flake state at devshell entry time, not the current staged changes. This meant users had to run `direnv reload` or manually invoke `nix run .#render-workflows` after modifying their workflow configuration.

**Root cause:** The hook used `packages.render-workflows` which has the workflow JSON pre-evaluated and baked into the derivation when the devshell is created.

**Fixes:**

- **fix(render): handle missing --evaluated-ci-path argument** - `Path(None)` raises TypeError, making the fresh nix eval code path unreachable despite the argument being marked as not required.

- **fix(pre-commit): use fresh nix eval instead of pre-evaluated JSON** - The hook now runs render.py without `--evaluated-ci-path`, triggering `nix eval` at commit time to pick up current working directory state.

- **fix(render): use correct attribute path after ci -> actions-nix rename** - The nix eval path `.#ci.workflows` was never updated when `flake.ci` was renamed to `flake.actions-nix` in c4f5168. This went unnoticed because the pre-commit hook always used pre-evaluated JSON.

## Test plan

- [x] Tested locally by overriding flake input to local checkout
- [x] Verified pre-commit hook now picks up staged changes without `direnv reload`