### PR TITLE
Support jj for repo root checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ pre-commit.settings.hooks.render-actions = {
 };
 ```
 
+### Using Jujutsu (jj) to find the repo root
+
+There is built-in, optional support for Jujutsu VCS via the option:
+
+```nix
+flake.actions-nix.useJJ = true # default: `false`
+```
+
+If enabled, locating the repo root will be tried with jj first and fallback to the usual approach git.
+
+This is useful if you use jj workspaces where there isn't a git root available or if you don't use git-backed repos.
+
+The `--no-prepend-git-root` flag also affects this option.
+
 ## About
 
 This is a work-in-progress project. My plan is to implement all

--- a/nix/flake-modules/actions-nix/ci.nix
+++ b/nix/flake-modules/actions-nix/ci.nix
@@ -92,6 +92,17 @@ let
           `actions-nix.workflows` attribute set
         '';
       };
+      useJJ = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to use jj (Jujutsu) for repository root detection
+          instead of git during workflow rendering. When enabled, jj will be
+          used to find the repository root and fallback to git as normal. This
+          is useful if you use jj workspaces where there isn't a git root
+          available.
+        '';
+      };
       # render-package = {
       #   enable = lib.mkEnableOption ''
       #     addition of a package definition to `perSystem.packages.render-workflows` for rendering workflows.

--- a/nix/flake-modules/actions-nix/default.nix
+++ b/nix/flake-modules/actions-nix/default.nix
@@ -58,8 +58,8 @@ _localFlake:
             name = "render-workflows";
             runtimeInputs = [
               pkgs.git
-              pkgs.jj
-            ];
+            ]
+            ++ lib.optional config.flake.actions-nix.useJJ pkgs.jj;
             text =
               let
                 pythonEnv = pkgs.python3.withPackages (p: [ p.pyyaml ]);
@@ -67,9 +67,14 @@ _localFlake:
                   name = "evaluated-ci.json";
                   text = builtins.toJSON config.flake.actions-nix.workflows;
                 };
-                cmdLine = lib.cli.toCommandLineShellGNU { } {
-                  evaluated-ci-path = evaluatedCI;
-                };
+                cmdLine = lib.cli.toCommandLineShellGNU { } (
+                  {
+                    evaluated-ci-path = evaluatedCI;
+                  }
+                  // lib.optionalAttrs config.flake.actions-nix.useJJ {
+                    use-jj = true;
+                  }
+                );
               in
               ''
                 ${pythonEnv}/bin/python3 ${./render.py} ${cmdLine}

--- a/nix/flake-modules/actions-nix/default.nix
+++ b/nix/flake-modules/actions-nix/default.nix
@@ -56,7 +56,10 @@ _localFlake:
         packages.render-workflows =
           (pkgs.writeShellApplication {
             name = "render-workflows";
-            runtimeInputs = [ pkgs.git ];
+            runtimeInputs = [
+              pkgs.git
+              pkgs.jj
+            ];
             text =
               let
                 pythonEnv = pkgs.python3.withPackages (p: [ p.pyyaml ]);

--- a/nix/flake-modules/actions-nix/render.py
+++ b/nix/flake-modules/actions-nix/render.py
@@ -37,19 +37,24 @@ def yaml_multiline_string_pipe(dumper, data):
 
 yaml.add_representer(str, yaml_multiline_string_pipe)
 
-def get_repo_root() -> Path:
-    for cmd in [["jj", "root"], ["git", "rev-parse", "--show-toplevel"]]:
+def get_repo_root(use_jj: bool = False) -> Path:
+    cmds = []
+    if use_jj:
+        cmds.append(["jj", "workspace", "root"])
+    cmds.append(["git", "rev-parse", "--show-toplevel"])
+    for cmd in cmds:
         result = subprocess.run(
             cmd,
             text=True,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode == 0:
             return Path(result.stdout.strip())
-    raise RuntimeError("Neither jj nor git found a repository root")
+    raise RuntimeError("Repository root could not be found")
 
-def main(evaluated_ci_path: Optional[Path], prepend_git_root: bool = True):
-    git_toplevel = get_repo_root() if prepend_git_root else None
+def main(evaluated_ci_path: Optional[Path], prepend_git_root: bool = True, use_jj: bool = False):
+    git_toplevel = get_repo_root(use_jj=use_jj) if prepend_git_root else None
 
     if evaluated_ci_path is None:
         eval_process = partial(
@@ -94,9 +99,15 @@ if __name__ == "__main__":
         action="store_true",
         help="Do not prepend the git repo root to workflow paths"
     )
+    argparser.add_argument(
+        "--use-jj",
+        action="store_true",
+        help="Use jj (Jujutsu) for repository root detection and fallback to git"
+    )
     args = argparser.parse_args()
     main(
         evaluated_ci_path=Path(args.evaluated_ci_path) if args.evaluated_ci_path else None,
         prepend_git_root=not args.no_prepend_git_root,
+        use_jj=args.use_jj,
     )
 

--- a/nix/flake-modules/actions-nix/render.py
+++ b/nix/flake-modules/actions-nix/render.py
@@ -37,17 +37,19 @@ def yaml_multiline_string_pipe(dumper, data):
 
 yaml.add_representer(str, yaml_multiline_string_pipe)
 
-def get_git_toplevel() -> Path:
-    result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        text=True,
-        capture_output=True,
-        check=True,
-    )
-    return Path(result.stdout.strip())
+def get_repo_root() -> Path:
+    for cmd in [["jj", "root"], ["git", "rev-parse", "--show-toplevel"]]:
+        result = subprocess.run(
+            cmd,
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    raise RuntimeError("Neither jj nor git found a repository root")
 
 def main(evaluated_ci_path: Optional[Path], prepend_git_root: bool = True):
-    git_toplevel = get_git_toplevel() if prepend_git_root else None
+    git_toplevel = get_repo_root() if prepend_git_root else None
 
     if evaluated_ci_path is None:
         eval_process = partial(


### PR DESCRIPTION
Jujutsu (jj), if you are unfamiliar, is a git-compatible VCS: https://github.com/jj-vcs/jj

In jj worktrees I noticed I can't render workflows because they're independent from git unlike a lot of jj and `get_git_toplevel()` fails. 

I've tested this in both git, jj, and git+jj scenarios and it works perfectly.